### PR TITLE
MethodCallCollector: Remove exception case

### DIFF
--- a/src/MethodCallCollector.php
+++ b/src/MethodCallCollector.php
@@ -27,9 +27,9 @@ class MethodCallCollector implements Collector
 
     public function processNode(Node $node, Scope $scope)
     {
-		$methodName = $node->name;
+	    $methodName = $node->name;
 	    if (! $methodName instanceof Node\Identifier) {
-		    throw new LogicException('WTF');
+		    return [];
 	    }
 	    $type = $scope->getType($node->var);
 		$type = (string) $scope->getMethodReflection($type, $methodName->name)?->getDeclaringClass()->getName();


### PR DESCRIPTION
in the following example the `MethodCall` won't have a `Identifier` name.

we should just skip these (instead of throwing out)
```php
class Foo {
  public function doBar(string $method) {
    $this->$method();
  }
}
```